### PR TITLE
fix: 강의 추천글 저장 누락 수정

### DIFF
--- a/src/main/java/nbc/devmountain/domain/chat/service/ChatService.java
+++ b/src/main/java/nbc/devmountain/domain/chat/service/ChatService.java
@@ -31,9 +31,9 @@ public class ChatService {
 
 		if (membershipType == User.MembershipLevel.GUEST) {
 			Integer guestCount = (Integer)session.getAttributes().getOrDefault("guestCount", 0);
-			if (guestCount >= 5) {
+			if (guestCount >= 10) {
 				ChatMessageResponse limitMsg = ChatMessageResponse.builder()
-					.message("비회원은 최대 5개의 메세지만 보낼 수 있습니다. 더 이용하려면 로그인을 해주세요.")
+					.message("비회원은 최대 10개의 메세지만 보낼 수 있습니다. 더 이용하려면 로그인을 해주세요.")
 					.isAiResponse(true)
 					.messageType(MessageType.ERROR)
 					.build();
@@ -52,9 +52,15 @@ public class ChatService {
 		ChatMessageResponse aiResponse = recommendationService.recommendationResponse(payload, membershipType, roomId,
 			session);
 
-		if (aiResponse.getMessageType() == MessageType.RECOMMENDATION && aiResponse.getRecommendations() != null
-			&& !aiResponse.getRecommendations().isEmpty()) {
-			messageSender.sendMessageToRoom(roomId, aiResponse);
+		if (aiResponse.getMessageType() == MessageType.RECOMMENDATION) {
+			ChatMessageResponse aiMsg;
+			if (membershipType != User.MembershipLevel.GUEST) {
+				aiMsg = chatMessageService.createAIMessage(roomId, aiResponse);
+				log.info("AI 추천 메시지 생성 완료");
+			} else {
+				aiMsg = aiResponse;
+			}
+			messageSender.sendMessageToRoom(roomId, aiMsg);
 		}
 	}
 


### PR DESCRIPTION
## 📌 이슈

채팅방을 새로고침 하는 과정에서 강의추천 카드가 불러와지지 않은 이슈가 있었는데,
원인은 메시지 타입이  Recommendation 인 AI채팅이 채팅 히스토리에 반영되지 않았고,
Recommendation 타입의 메시지를  DB에 저장하는 과정에 누락 있었습니다.

추가로 비회원의 메세지 횟수를 넉넉하게 수정.

## ✨ 기능 요약
<!--
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | 기능 이름을 간단히 요약 |
| 🔍 목적 | 해당 기능이 왜 필요한지 간략 설명 |
| 🛠️ 변경사항 | 핵심 변경 포인트 간략히 요약 (예: UI 추가, API 연동 등) |
--> 


## 📝 상세 내역
<!--
| 번호 | 내용 |
|------|------|
| 1️⃣ | 주요 로직/컴포넌트/서비스 등 변경 설명 |
| 2️⃣ | 관련 유틸, 공통 로직 수정 여부 |
| 3️⃣ | 리팩토링 또는 제거된 불필요 코드 |
--> 
---

✅ 테스트 체크리스트
<!-- 테스트 할 내용이 있다면 작성해주세요
- [ ] 기능 정상 작동 확인
- [ ] 예외/엣지 케이스 확인
- [ ] UI/UX 흐름 확인 (필요 시 캡처 또는 영상 첨부)
- [ ] 테스트 코드 작성 완료
- [ ] API 연동 확인 (요청/응답 정상 동작)
--> 
---

## 📸 실행화면 캡처 사진


---

## 🙋‍♀️ 리뷰어 참고사항
<!-- 
- 테스트 방법
- 주요 로직 설명
- 리뷰 시 중점적으로 봐주셨으면 하는 부분
- 코드 스타일 관련 사항 등
--> 
